### PR TITLE
Improve Prisma setup for Vercel compatibility

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -1,0 +1,7 @@
+# Copy this file to .env or .env.local and fill in your values.
+# Vercel: set these in Project Settings -> Environment Variables.
+
+# PostgreSQL connection string
+# Example: postgres://USER:PASSWORD@HOST:PORT/DATABASE
+DATABASE_URL="postgres://USER:PASSWORD@HOST:5432/DBNAME"
+

--- a/.gitignore
+++ b/.gitignore
@@ -33,6 +33,9 @@ yarn-error.log*
 # env files (can opt-in for committing if needed)
 .env*
 
+# allow example env file
+!.env.example
+
 # vercel
 .vercel
 
@@ -40,3 +43,4 @@ yarn-error.log*
 *.tsbuildinfo
 next-env.d.ts
 .env*.local
+

--- a/README.md
+++ b/README.md
@@ -20,6 +20,20 @@ You can start editing the page by modifying `app/page.tsx`. The page auto-update
 
 This project uses [`next/font`](https://nextjs.org/docs/app/building-your-application/optimizing/fonts) to automatically optimize and load [Geist](https://vercel.com/font), a new font family for Vercel.
 
+## Prisma setup
+
+- The Prisma Client is generated automatically on install via the `postinstall` script.
+- Configure your database connection string via `DATABASE_URL`.
+  - Local development: copy `.env.example` to `.env.local` and set `DATABASE_URL`.
+  - Vercel: set `DATABASE_URL` in Project Settings → Environment Variables. Vercel injects env vars at build and runtime, and Prisma Client will use `process.env.DATABASE_URL`.
+- The Prisma schema lives in `prisma/schema.prisma`. Update it and run:
+
+```bash
+npm run prisma:generate
+```
+
+> Note: Prisma CLI reads environment variables from `.env` files. While Next.js also supports `.env.local`, Prisma commands run fine without a database connection for `prisma generate`. For commands that need a DB (e.g. `migrate`), either define `DATABASE_URL` in `.env` or export it in your shell before running Prisma commands.
+
 ## Learn More
 
 To learn more about Next.js, take a look at the following resources:
@@ -34,3 +48,4 @@ You can check out [the Next.js GitHub repository](https://github.com/vercel/next
 The easiest way to deploy your Next.js app is to use the [Vercel Platform](https://vercel.com/new?utm_medium=default-template&filter=next.js&utm_source=create-next-app&utm_campaign=create-next-app-readme) from the creators of Next.js.
 
 Check out our [Next.js deployment documentation](https://nextjs.org/docs/app/building-your-application/deploying) for more details.
+

--- a/package.json
+++ b/package.json
@@ -6,7 +6,9 @@
     "dev": "next dev --turbopack",
     "build": "next build --turbopack",
     "start": "next start",
-    "lint": "eslint"
+    "lint": "eslint",
+    "prisma:generate": "prisma generate",
+    "postinstall": "prisma generate"
   },
   "dependencies": {
     "@prisma/client": "^6.15.0",
@@ -28,3 +30,4 @@
     "typescript": "^5"
   }
 }
+

--- a/prisma/schema.prisma
+++ b/prisma/schema.prisma
@@ -1,4 +1,9 @@
+generator client {
+  provider = "prisma-client-js"
+}
+
 datasource db {
   provider = "postgresql"
   url      = env("DATABASE_URL")
 }
+


### PR DESCRIPTION
This PR enhances the Prisma setup to work smoothly in both local development and on Vercel.

What changed
- Add generator client to prisma/schema.prisma so Prisma Client can be generated and used.
- Add postinstall script (prisma generate) to ensure the client is built automatically after install (useful for Vercel builds).
- Add prisma:generate script for manual generation during development.
- Provide .env.example and README guidance on configuring DATABASE_URL locally and on Vercel.
- Update .gitignore to allow committing .env.example.

Why
- Vercel relies on environment variables set in the project settings, and local development often uses .env.local. Prisma Client generation is needed after install and should happen automatically in CI/CD.
- Without the generator block, Prisma Client would not be created. With the postinstall hook, the client is generated reliably during installations and Vercel builds.

How to use
- Local: copy .env.example to .env.local and set DATABASE_URL, then run npm install (or npm run prisma:generate) to generate the client.
- Vercel: set DATABASE_URL in Project Settings → Environment Variables. The postinstall will run during the build and generate Prisma Client without requiring a local .env file.

No runtime code changes were made beyond Prisma configuration, keeping the change minimal and focused.

Closes #3