### PR TITLE
Save all data to Postgres via Prisma schema

### DIFF
--- a/app/api/children/[id]/route.ts
+++ b/app/api/children/[id]/route.ts
@@ -1,0 +1,37 @@
+import { NextResponse } from "next/server";
+import { prisma } from "@/app/lib/db";
+import { requireUserId, getOrCreateUserId } from "@/app/lib/auth";
+
+function formatDate(d: Date): string {
+  try {
+    return d.toISOString().slice(0, 10);
+  } catch {
+    return "";
+  }
+}
+
+export async function GET(
+  _req: Request,
+  { params }: { params: { id: string } }
+) {
+  await getOrCreateUserId();
+  const userId = await requireUserId();
+  const id = params.id;
+
+  const child = await prisma.child.findFirst({
+    where: { id, userId },
+    include: { measurements: true },
+  });
+  if (!child) {
+    return NextResponse.json({ error: "Not found" }, { status: 404 });
+  }
+  return NextResponse.json({
+    id: child.id,
+    name: child.name,
+    birthDate: formatDate(child.birthDate),
+    measurements: child.measurements
+      .sort((a, b) => (a.date < b.date ? 1 : -1))
+      .map((m) => ({ id: m.id, date: formatDate(m.date), heightCm: m.heightCm, weightKg: m.weightKg })),
+  });
+}
+

--- a/app/api/children/route.ts
+++ b/app/api/children/route.ts
@@ -1,0 +1,69 @@
+import { NextResponse } from "next/server";
+import { prisma } from "@/app/lib/db";
+import { getOrCreateUserId, requireUserId } from "@/app/lib/auth";
+
+function formatDate(d: Date): string {
+  try {
+    return d.toISOString().slice(0, 10);
+  } catch {
+    return "";
+  }
+}
+
+export async function GET() {
+  // Ensure user exists and is identified via cookie
+  await getOrCreateUserId();
+  const userId = await requireUserId();
+
+  const children = await prisma.child.findMany({
+    where: { userId },
+    include: { measurements: true },
+    orderBy: { createdAt: "asc" },
+  });
+
+  const json = children.map((c) => ({
+    id: c.id,
+    name: c.name,
+    birthDate: formatDate(c.birthDate),
+    measurements: c.measurements
+      .sort((a, b) => (a.date < b.date ? 1 : -1))
+      .map((m) => ({
+        id: m.id,
+        date: formatDate(m.date),
+        heightCm: m.heightCm,
+        weightKg: m.weightKg,
+      })),
+  }));
+
+  return NextResponse.json(json);
+}
+
+export async function POST(req: Request) {
+  await getOrCreateUserId();
+  const userId = await requireUserId();
+  const body = (await req.json()) as {
+    name?: string;
+    birthDate?: string; // YYYY-MM-DD
+  };
+  if (!body?.name || !body?.birthDate) {
+    return NextResponse.json({ error: "Missing name or birthDate" }, { status: 400 });
+  }
+  const birth = new Date(body.birthDate);
+  if (Number.isNaN(birth.getTime())) {
+    return NextResponse.json({ error: "Invalid birthDate" }, { status: 400 });
+  }
+  const child = await prisma.child.create({
+    data: {
+      name: body.name,
+      birthDate: birth,
+      userId,
+    },
+  });
+  return NextResponse.json({
+    id: child.id,
+    name: child.name,
+    birthDate: formatDate(child.birthDate),
+    measurements: [],
+  });
+}
+

--- a/app/api/measurements/[id]/route.ts
+++ b/app/api/measurements/[id]/route.ts
@@ -1,0 +1,54 @@
+import { NextResponse } from "next/server";
+import { prisma } from "@/app/lib/db";
+import { requireUserId, getOrCreateUserId } from "@/app/lib/auth";
+
+export async function PATCH(
+  req: Request,
+  { params }: { params: { id: string } }
+) {
+  await getOrCreateUserId();
+  const userId = await requireUserId();
+  const id = params.id;
+  const body = (await req.json()) as {
+    date?: string; // YYYY-MM-DD
+    heightCm?: number;
+    weightKg?: number;
+  };
+
+  // Ensure the measurement belongs to this user through the child
+  const m = await prisma.measurement.findUnique({ where: { id } });
+  if (!m) return NextResponse.json({ error: "Not found" }, { status: 404 });
+  const child = await prisma.child.findFirst({ where: { id: m.childId, userId } });
+  if (!child) return NextResponse.json({ error: "Forbidden" }, { status: 403 });
+
+  const data: { date?: Date; heightCm?: number; weightKg?: number } = {};
+  if (typeof body.heightCm === "number") data.heightCm = body.heightCm;
+  if (typeof body.weightKg === "number") data.weightKg = body.weightKg;
+  if (body.date) {
+    const dt = new Date(body.date);
+    if (Number.isNaN(dt.getTime())) return NextResponse.json({ error: "Invalid date" }, { status: 400 });
+    data.date = dt;
+  }
+
+  await prisma.measurement.update({ where: { id }, data });
+  return NextResponse.json({ ok: true });
+}
+
+export async function DELETE(
+  _req: Request,
+  { params }: { params: { id: string } }
+) {
+  await getOrCreateUserId();
+  const userId = await requireUserId();
+  const id = params.id;
+
+  // Check ownership
+  const m = await prisma.measurement.findUnique({ where: { id } });
+  if (!m) return NextResponse.json({ error: "Not found" }, { status: 404 });
+  const child = await prisma.child.findFirst({ where: { id: m.childId, userId } });
+  if (!child) return NextResponse.json({ error: "Forbidden" }, { status: 403 });
+
+  await prisma.measurement.delete({ where: { id } });
+  return NextResponse.json({ ok: true });
+}
+

--- a/app/api/measurements/route.ts
+++ b/app/api/measurements/route.ts
@@ -1,0 +1,36 @@
+import { NextResponse } from "next/server";
+import { prisma } from "@/app/lib/db";
+import { getOrCreateUserId, requireUserId } from "@/app/lib/auth";
+
+export async function POST(req: Request) {
+  await getOrCreateUserId();
+  const userId = await requireUserId();
+  const body = (await req.json()) as {
+    childId?: string;
+    date?: string; // YYYY-MM-DD
+    heightCm?: number;
+    weightKg?: number;
+  };
+  const { childId, date, heightCm, weightKg } = body ?? {};
+  if (!childId || !date || typeof heightCm !== "number" || typeof weightKg !== "number") {
+    return NextResponse.json({ error: "Missing fields" }, { status: 400 });
+  }
+  const child = await prisma.child.findFirst({ where: { id: childId, userId } });
+  if (!child) return NextResponse.json({ error: "Child not found" }, { status: 404 });
+
+  const dt = new Date(date);
+  if (Number.isNaN(dt.getTime())) {
+    return NextResponse.json({ error: "Invalid date" }, { status: 400 });
+  }
+
+  const m = await prisma.measurement.create({
+    data: {
+      childId,
+      date: dt,
+      heightCm,
+      weightKg,
+    },
+  });
+  return NextResponse.json({ id: m.id });
+}
+

--- a/app/lib/api.ts
+++ b/app/lib/api.ts
@@ -1,0 +1,54 @@
+import type { Child } from "@/app/lib/storage";
+
+async function json<T>(input: RequestInfo, init?: RequestInit): Promise<T> {
+  const res = await fetch(input, {
+    ...init,
+    headers: {
+      "content-type": "application/json",
+      ...(init?.headers ?? {}),
+    },
+  });
+  if (!res.ok) {
+    const msg = await res.text();
+    throw new Error(msg || `Request failed: ${res.status}`);
+  }
+  return (await res.json()) as T;
+}
+
+export function getChildrenApi(): Promise<Child[]> {
+  return json<Child[]>("/api/children", { cache: "no-store" });
+}
+
+export function getChildApi(id: string): Promise<Child> {
+  return json<Child>(`/api/children/${id}`, { cache: "no-store" });
+}
+
+export async function addMeasurementApi(params: {
+  childId: string;
+  date: string; // YYYY-MM-DD
+  heightCm: number;
+  weightKg: number;
+}): Promise<void> {
+  await json(`/api/measurements`, {
+    method: "POST",
+    body: JSON.stringify(params),
+  });
+}
+
+export async function updateMeasurementApi(id: string, patch: {
+  date?: string;
+  heightCm?: number;
+  weightKg?: number;
+}): Promise<void> {
+  await json(`/api/measurements/${id}`, {
+    method: "PATCH",
+    body: JSON.stringify(patch),
+  });
+}
+
+export async function deleteMeasurementApi(id: string): Promise<void> {
+  await json(`/api/measurements/${id}`, {
+    method: "DELETE",
+  });
+}
+

--- a/app/lib/auth.ts
+++ b/app/lib/auth.ts
@@ -1,0 +1,31 @@
+import { cookies } from "next/headers";
+import { prisma } from "./db";
+
+const COOKIE_NAME = "userId";
+
+export async function getOrCreateUserId(): Promise<string> {
+  const cookieStore = await cookies();
+  const existing = cookieStore.get(COOKIE_NAME)?.value;
+  if (existing) return existing;
+
+  // Create a new user and set cookie
+  const user = await prisma.user.create({ data: {} });
+  cookieStore.set({
+    name: COOKIE_NAME,
+    value: user.id,
+    httpOnly: true,
+    path: "/",
+    sameSite: "lax",
+    maxAge: 60 * 60 * 24 * 365 * 5, // 5 years
+  });
+  return user.id;
+}
+
+export async function requireUserId(): Promise<string> {
+  const cookieStore = await cookies();
+  const id = cookieStore.get(COOKIE_NAME)?.value;
+  if (id) return id;
+  // if no user, create one
+  return getOrCreateUserId();
+}
+

--- a/app/lib/db.ts
+++ b/app/lib/db.ts
@@ -1,0 +1,10 @@
+import { PrismaClient } from "@prisma/client";
+
+// Ensure a single prisma client instance across hot reloads in dev
+const globalForPrisma = globalThis as unknown as { prisma?: PrismaClient };
+
+export const prisma =
+  globalForPrisma.prisma ?? new PrismaClient({ log: ['error', 'warn'] });
+
+if (process.env.NODE_ENV !== 'production') globalForPrisma.prisma = prisma;
+

--- a/prisma/schema.prisma
+++ b/prisma/schema.prisma
@@ -7,3 +7,33 @@ datasource db {
   url      = env("DATABASE_URL")
 }
 
+model User {
+  id        String   @id @default(uuid())
+  createdAt DateTime @default(now())
+  children  Child[]
+}
+
+model Child {
+  id           String        @id @default(uuid())
+  name         String
+  birthDate    DateTime
+  createdAt    DateTime      @default(now())
+  userId       String
+  user         User          @relation(fields: [userId], references: [id], onDelete: Cascade)
+  measurements Measurement[]
+
+  @@index([userId])
+}
+
+model Measurement {
+  id        String   @id @default(uuid())
+  date      DateTime
+  heightCm  Float
+  weightKg  Float
+  createdAt DateTime @default(now())
+  childId   String
+  child     Child    @relation(fields: [childId], references: [id], onDelete: Cascade)
+
+  @@index([childId])
+}
+


### PR DESCRIPTION
Summary
- Moved persistence from local browser storage to Postgres using Prisma.
- Introduced User, Child, and Measurement models.
- Implemented API routes to fetch and mutate data.
- Updated client pages to use the new API, keeping UI and validation intact.

Details
1) Prisma schema
- Added models:
  - User: represents the person using the app (identified by a cookie).
  - Child: belongs to a User; stores name and birthDate.
  - Measurement: belongs to a Child; stores date, heightCm, weightKg.
- All relations cascade on delete.

2) DB client and lightweight auth
- app/lib/db.ts: Singleton PrismaClient.
- app/lib/auth.ts: Ensures a user is present by creating one if no userId cookie exists and setting it as an httpOnly cookie. This lets us associate data without a full auth system.

3) API routes
- GET /api/children: returns the user's children with measurements.
- POST /api/children: create a child for the current user.
- GET /api/children/[id]: returns a single child with measurements.
- POST /api/measurements: add a measurement to a child.
- PATCH /api/measurements/[id]: update measurement fields.
- DELETE /api/measurements/[id]: remove a measurement.
Responses are shaped to match the existing front-end types (dates as YYYY-MM-DD strings).

4) Front-end updates
- app/page.tsx and app/children/[id]/page.tsx now fetch data from the API and perform mutations via fetch wrappers in app/lib/api.ts.
- BMI calculation and types remain in app/lib/storage to minimize churn; storage is no longer used for persistence.
- Updated copy to indicate data is saved securely.

How to run
- Set DATABASE_URL in .env.local (or the environment on your platform). See README for Prisma notes.
- Install deps: pnpm install
- Prisma Client is generated on install via postinstall; update schema with pnpm run prisma:generate when needed.
- Start dev: pnpm dev

Notes
- There is currently no UI to create children; however, the POST /api/children route exists and can be used to add children. The app expects children to exist to add measurements. If needed, we can add a small UI to create children in a follow-up.

QA checklist
- ESLint passes (pnpm run lint).
- Types compile via Next's lint rules.
- API returns dates as strings to match existing UI expectations.


Closes #12