### PR TITLE
Add navy blue accents and gradients to UI

### DIFF
--- a/app/globals.css
+++ b/app/globals.css
@@ -1,26 +1,70 @@
 @import "tailwindcss";
 
 :root {
-  --background: #ffffff;
-  --foreground: #171717;
+  /* Core palette */
+  --background: #ffffff; /* kept solid for text-background usage */
+  --foreground: #0b1b3b; /* deep navy for primary text and accents */
+
+  --accent: #1e3a8a; /* navy blue */
+  --accent-foreground: #e6efff; /* very light blue for contrast on accent */
+
+  /* Gradient system (light) */
+  --bg-start: #ffffff;
+  --bg-end: #f5f8ff; /* subtle blue tint */
+  --glow-1: rgba(30, 58, 138, 0.12); /* accent glow */
+  --glow-2: rgba(2, 6, 23, 0.12); /* deep shadow glow */
+  --page-gradient:
+    radial-gradient(900px 450px at -10% -20%, var(--glow-1), transparent 60%),
+    radial-gradient(700px 500px at 110% 120%, var(--glow-2), transparent 60%),
+    linear-gradient(to bottom, var(--bg-start), var(--bg-end));
 }
 
 @theme inline {
   --color-background: var(--background);
   --color-foreground: var(--foreground);
+  --color-accent: var(--accent);
+  --color-accent-foreground: var(--accent-foreground);
   --font-sans: var(--font-geist-sans);
   --font-mono: var(--font-geist-mono);
 }
 
 @media (prefers-color-scheme: dark) {
   :root {
-    --background: #0a0a0a;
-    --foreground: #ededed;
+    --background: #0a0f1f; /* deep navy */
+    --foreground: #e6efff; /* soft light */
+
+    --bg-start: #0a0f1f;
+    --bg-end: #0b1329;
+    --glow-1: rgba(59, 130, 246, 0.14); /* brighter blue glow */
+    --glow-2: rgba(2, 6, 23, 0.4);
   }
 }
 
+/* Global canvas */
 body {
-  background: var(--background);
+  background-color: var(--background);
+  background-image: var(--page-gradient);
   color: var(--foreground);
   font-family: Arial, Helvetica, sans-serif;
 }
+
+/* Subtle, consistent accents */
+::selection {
+  background: var(--accent);
+  color: white;
+}
+
+a {
+  color: var(--accent);
+  text-underline-offset: 2px;
+}
+
+a:hover {
+  text-decoration-thickness: 2px;
+}
+
+:focus-visible {
+  outline: 2px solid var(--accent);
+  outline-offset: 2px;
+}
+


### PR DESCRIPTION
This PR updates the global styling to introduce a navy blue accent and tasteful gradients across the app, addressing the request to "add some cool color" with navy accents and gradients.

What changed
- New CSS variables for a navy palette: --accent, --accent-foreground, and a deeper navy --foreground for primary text
- Subtle light/dark gradient backgrounds using radial glows and a soft linear gradient
- Exposed accent tokens to Tailwind via @theme inline for easy use in utilities
- Improved base UX details: selection color, focus outline, and link color utilize the accent

Key implementation notes
- The --background token remains a solid color to ensure text-background usage stays valid (avoids gradient-as-text issues)
- Body now uses background-image for the gradient while preserving background-color for contrast
- Dark mode receives complementary deep navy tones with slightly brighter blue glows

No component code changes were required; existing Tailwind classes automatically pick up the updated variables. This keeps the change scoped, safe, and easy to revert/adjust.

Checks
- Installed dependencies with pnpm (pnpm-lock.yaml present)
- Linting passes: pnpm run lint

Closes #16