### PR TITLE
Improve date picker to clearly show default date

### DIFF
--- a/app/children/[id]/page.tsx
+++ b/app/children/[id]/page.tsx
@@ -11,6 +11,7 @@ import {
   saveChildren,
   getChildren,
 } from "@/app/lib/storage";
+import { todayYmdLocal } from "@/app/lib/date";
 
 function formatBMI(bmi: number) {
   if (!Number.isFinite(bmi) || bmi <= 0) return "–";
@@ -27,7 +28,7 @@ export default function ChildDetailPage() {
   const [error, setError] = useState<string | null>(null);
 
   // Add form state
-  const [date, setDate] = useState("");
+  const [date, setDate] = useState(todayYmdLocal());
   const [heightCm, setHeightCm] = useState<string>("");
   const [weightKg, setWeightKg] = useState<string>("");
 
@@ -83,7 +84,7 @@ export default function ChildDetailPage() {
       heightCm: Number(heightCm),
       weightKg: Number(weightKg),
     });
-    setDate("");
+    setDate(todayYmdLocal());
     setHeightCm("");
     setWeightKg("");
     refresh();
@@ -185,6 +186,7 @@ export default function ChildDetailPage() {
               id="date"
               type="date"
               value={date}
+              max={todayYmdLocal()}
               onChange={(e) => setDate(e.target.value)}
               className="h-10 rounded-md px-3 border border-black/10 dark:border-white/20 bg-transparent"
             />
@@ -248,6 +250,7 @@ export default function ChildDetailPage() {
                           <input
                             type="date"
                             value={eDate}
+                            max={todayYmdLocal()}
                             onChange={(e) => setEDate(e.target.value)}
                             className="h-9 w-full rounded-md px-2 border border-black/10 dark:border-white/20 bg-transparent"
                           />

--- a/app/lib/date.ts
+++ b/app/lib/date.ts
@@ -1,0 +1,7 @@
+export function todayYmdLocal(): string {
+  // Returns local date in YYYY-MM-DD, avoiding UTC offset issues
+  const d = new Date();
+  d.setMinutes(d.getMinutes() - d.getTimezoneOffset());
+  return d.toISOString().slice(0, 10);
+}
+

--- a/app/page.tsx
+++ b/app/page.tsx
@@ -9,6 +9,7 @@ import {
   getChildren,
   saveChildren,
 } from "@/app/lib/storage";
+import { todayYmdLocal } from "@/app/lib/date";
 
 function formatBMI(bmi: number) {
   if (!Number.isFinite(bmi) || bmi <= 0) return "–";
@@ -22,7 +23,7 @@ export default function Home() {
   const [error, setError] = useState<string | null>(null);
 
   // Add form state (per active child)
-  const [date, setDate] = useState("");
+  const [date, setDate] = useState(todayYmdLocal());
   const [heightCm, setHeightCm] = useState<string>("");
   const [weightKg, setWeightKg] = useState<string>("");
 
@@ -72,7 +73,7 @@ export default function Home() {
   }
 
   function resetForms() {
-    setDate("");
+    setDate(todayYmdLocal());
     setHeightCm("");
     setWeightKg("");
     setEditingId(null);
@@ -96,7 +97,7 @@ export default function Home() {
       heightCm: Number(heightCm),
       weightKg: Number(weightKg),
     });
-    setDate("");
+    setDate(todayYmdLocal());
     setHeightCm("");
     setWeightKg("");
     refresh();
@@ -212,6 +213,7 @@ export default function Home() {
                       id="date"
                       type="date"
                       value={date}
+                      max={todayYmdLocal()}
                       onChange={(e) => setDate(e.target.value)}
                       className="h-10 rounded-md px-3 border border-black/10 dark:border-white/20 bg-transparent"
                     />
@@ -272,6 +274,7 @@ export default function Home() {
                                   <input
                                     type="date"
                                     value={eDate}
+                                    max={todayYmdLocal()}
                                     onChange={(e) => setEDate(e.target.value)}
                                     className="h-9 w-full rounded-md px-2 border border-black/10 dark:border-white/20 bg-transparent"
                                   />


### PR DESCRIPTION
Problem
Users reported that the date picker can feel empty or unintuitive: typing a number and pressing OK sometimes leaves the field blank because no valid date was selected/typed, making it unclear whether a date is set.

Solution
- Introduced a small utility todayYmdLocal() that returns the local date as YYYY-MM-DD to avoid UTC offset issues.
- Prefill the Add measurement date inputs with today’s date so there is always a clear, valid default.
- Reset the date field back to today after adding a measurement or switching children, instead of leaving it empty.
- Added max={todayYmdLocal()} on date inputs to prevent selecting future dates (in line with validation) and provide stronger visual affordance.

Files changed
- app/lib/date.ts (new): utility for local YYYY-MM-DD.
- app/page.tsx: use todayYmdLocal() for initial state, reset, and as max on date inputs.
- app/children/[id]/page.tsx: same changes as above for the detail page.

Why this approach?
- Keeps UX simple and intuitive by showing a valid default immediately.
- Minimizes code changes and keeps logic consistent with existing validation rules.
- Avoids timezone-related off-by-one issues by formatting the date using local time.

Checks
- Ran pnpm install and pnpm run lint; ESLint passes with no issues.

If desired, we could also add placeholder="YYYY-MM-DD" to the date inputs, but since they are now prefilled the field content is already clear.

Closes #20